### PR TITLE
add:csv読み込み

### DIFF
--- a/CSV_LOADING_ISSUE.md
+++ b/CSV_LOADING_ISSUE.md
@@ -1,0 +1,85 @@
+# CSV 読み込み問題の解決
+
+## ディレクトリ構造とパスの問題
+
+### ホスト側の構造
+
+```
+/Users/workspace/personal_dev/annoy_RunnestHub/  ← プロジェクトルート
+├── data/                    # CSVファイル（ここにアクセスしたい）
+│   ├── drinks.csv
+│   ├── users.csv
+│   └── interactions.csv
+├── python/                  # Pythonアプリ
+│   ├── main.py             # ここから ../data/ にアクセスしようとした
+│   ├── requirements.txt
+│   └── Dockerfile
+└── ruby/
+    ├── main.rb
+    └── Dockerfile
+```
+
+### コンテナ内の構造（修正前）
+
+```
+/app/                        ← Dockerコンテナ内
+├── main.py                 # ../data/ は存在しない！
+├── requirements.txt
+└── Dockerfile
+```
+
+### コンテナ内の構造（修正後）
+
+```
+/app/                        ← Dockerコンテナ内
+├── main.py                 # data/ でアクセス可能
+├── requirements.txt
+├── data/                   ← 追加された！
+│   ├── drinks.csv
+│   ├── users.csv
+│   └── interactions.csv
+└── Dockerfile
+```
+
+## 発生したエラー
+
+### エラー 1: FileNotFoundError
+
+```
+FileNotFoundError: [Errno 2] No such file or directory: '../data/drinks.csv'
+```
+
+**原因**: Docker コンテナ内に data ディレクトリがコピーされていない
+**解決**: Dockerfile に`COPY data /app/data`を追加
+
+### エラー 2: Docker ビルドエラー
+
+```
+ERROR: failed to solve: failed to compute cache key: "/data": not found
+```
+
+**原因**: プロジェクトルートからビルドする必要がある
+**解決**: `docker build -f Dockerfile -t python-app .`
+
+#### `-f`オプションとビルドコンテキストについて
+
+- プロジェクトルートからビルドする際、`Dockerfile`の場所を指定する必要がある
+- `-f Dockerfile`: 現在のディレクトリ（python）の Dockerfile を指定
+- `..`: ビルドコンテキストを親ディレクトリ（プロジェクトルート）に指定
+- これにより`python/`と`data/`の両方にアクセス可能
+
+### エラー 3: CSV 読み込みエラー
+
+```
+drinks.csvのshape: (11, 1)
+drinks.csvのcolumns: ['# drinks.csv']
+```
+
+**原因**: CSV ファイルのコメント行がヘッダーとして認識される
+**解決**: `pd.read_csv(path, comment='#')`でコメント行を無視
+
+## 修正内容
+
+1. **Dockerfile**: データディレクトリをコピー、ビルドコンテキスト用にパスを調整
+2. **main.py**: パスを`data`に変更、`comment='#'`を追加
+3. **実行方法**: `python`ディレクトリからビルドコンテキストを親ディレクトリに指定

--- a/README
+++ b/README
@@ -1,4 +1,6 @@
-docker build -t python-app .
+
+cd python
+docker build -f Dockerfile -t python-app ..
 docker run -it python-app python main.py
 
 docker build -t ruby-app .

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update && apt-get install -y \
    build-essential \
    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY requirements.txt .
+COPY python/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . /app
+COPY python/ /app
+COPY data /app/data
 CMD ["python", "main.py"]

--- a/python/main.py
+++ b/python/main.py
@@ -1,7 +1,56 @@
 # main.py
 import pandas as pd
 import numpy as np
+import os
 
 print("Hello from main.py!")
 print(f"Pandas version: {pd.__version__}")
 print(f"NumPy version: {np.__version__}")
+
+# CSVファイルのパスを設定
+data_dir = "data"
+drinks_path = os.path.join(data_dir, "drinks.csv")
+users_path = os.path.join(data_dir, "users.csv")
+interactions_path = os.path.join(data_dir, "interactions.csv")
+
+print("\n" + "="*50)
+print("1. drinks.csvを読み込み")
+print("="*50)
+
+# drinks.csvを読み込み
+drinks_df = pd.read_csv(drinks_path, comment='#')
+print("drinks.csvの内容:")
+print(drinks_df)
+
+print(f"\ndrinks.csvのshape: {drinks_df.shape}")
+print(f"drinks.csvのcolumns: {list(drinks_df.columns)}")
+print("\ndrinks.csvのhead():")
+print(drinks_df.head())
+
+print("\n" + "="*50)
+print("2. users.csvを読み込み")
+print("="*50)
+
+# users.csvを読み込み
+users_df = pd.read_csv(users_path, comment='#')
+print("users.csvの内容:")
+print(users_df)
+
+print(f"\nusers.csvのshape: {users_df.shape}")
+print(f"users.csvのcolumns: {list(users_df.columns)}")
+print("\nusers.csvのhead():")
+print(users_df.head())
+
+print("\n" + "="*50)
+print("3. interactions.csvを読み込み")
+print("="*50)
+
+# interactions.csvを読み込み
+interactions_df = pd.read_csv(interactions_path, comment='#')
+print("interactions.csvの内容:")
+print(interactions_df)
+
+print(f"\ninteractions.csvのshape: {interactions_df.shape}")
+print(f"interactions.csvのcolumns: {list(interactions_df.columns)}")
+print("\ninteractions.csvのhead():")
+print(interactions_df.head())


### PR DESCRIPTION
Close #3 
# CSV 読み込み実装とエラー解決

## ディレクトリ構造とパスの問題

### ホスト側の構造

```
/Users/workspace/personal_dev/annoy_RunnestHub/  ← プロジェクトルート
├── data/                    # CSVファイル（ここにアクセスしたい）
│   ├── drinks.csv
│   ├── users.csv
│   └── interactions.csv
├── python/                  # Pythonアプリ
│   ├── main.py             # ここから ../data/ にアクセスしようとした
│   ├── requirements.txt
│   └── Dockerfile
└── ruby/
    ├── main.rb
    └── Dockerfile
```

### コンテナ内の構造（修正前）

```
/app/                        ← Dockerコンテナ内
├── main.py                 # ../data/ は存在しない！
├── requirements.txt
└── Dockerfile
```

### コンテナ内の構造（修正後）

```
/app/                        ← Dockerコンテナ内
├── main.py                 # data/ でアクセス可能
├── requirements.txt
├── data/                   ← 追加された！
│   ├── drinks.csv
│   ├── users.csv
│   └── interactions.csv
└── Dockerfile
```

## 発生したエラー

### エラー 1: FileNotFoundError

```
FileNotFoundError: [Errno 2] No such file or directory: '../data/drinks.csv'
```

**原因**: Docker コンテナ内に data ディレクトリがコピーされていない
**解決**: Dockerfile に`COPY data /app/data`を追加

### エラー 2: Docker ビルドエラー

```
ERROR: failed to solve: failed to compute cache key: "/data": not found
```

**原因**: プロジェクトルートからビルドする必要がある
**解決**: `docker build -f Dockerfile -t python-app .`

#### `-f`オプションとビルドコンテキストについて

- プロジェクトルートからビルドする際、`Dockerfile`の場所を指定する必要がある
- `-f Dockerfile`: 現在のディレクトリ（python）の Dockerfile を指定
- `..`: ビルドコンテキストを親ディレクトリ（プロジェクトルート）に指定
- これにより`python/`と`data/`の両方にアクセス可能

### エラー 3: CSV 読み込みエラー

```
drinks.csvのshape: (11, 1)
drinks.csvのcolumns: ['# drinks.csv']
```

**原因**: CSV ファイルのコメント行がヘッダーとして認識される
**解決**: `pd.read_csv(path, comment='#')`でコメント行を無視

## 修正内容

1. **Dockerfile**: データディレクトリをコピー、ビルドコンテキスト用にパスを調整
2. **main.py**: パスを`data`に変更、`comment='#'`を追加
3. **実行方法**: `python`ディレクトリからビルドコンテキストを親ディレクトリに指定
