### PR TITLE
3-2. ingredients 列を分割してリスト化

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -54,3 +54,20 @@ print(f"\ninteractions.csvのshape: {interactions_df.shape}")
 print(f"interactions.csvのcolumns: {list(interactions_df.columns)}")
 print("\ninteractions.csvのhead():")
 print(interactions_df.head())
+
+print("\n" + "="*50)
+print("3-2. ingredients列を分割してリスト化")
+print("="*50)
+
+drinks_df['ingredients_list'] = drinks_df['ingredients'].str.split('|')
+print("ingredients列を分割した結果:")
+print(drinks_df[['name', 'ingredients', 'ingredients_list']])
+
+print(f"\n分割後のingredients_listの例:")
+for i, row in drinks_df.head(3).iterrows():
+    print(f"{row['name']}: {row['ingredients_list']}")
+
+print(f"\ningredients_list列のデータ型: {type(drinks_df['ingredients_list'].iloc[0])}")
+print(f"各飲み物の材料数:")
+for i, row in drinks_df.iterrows():
+    print(f"{row['name']}: {len(row['ingredients_list'])}個の材料")


### PR DESCRIPTION
Close #6 

## 概要

drinks.csv の ingredients 列を「|」で分割し、リスト形式に変換する機能を実装

## 実装内容

### 変更ファイル

- `python/main.py`: ingredients 列の分割処理を追加

### 実装詳細

#### 1. ingredients 列の分割処理
- splitで分割

## データ変換例

### 変換前

```
ingredients: "shochu|soda|lemon"
```

### 変換後

```
ingredients_list: ["shochu", "soda", "lemon"]
```

## 実装理由

### 1. データ分析の効率化

- 文字列のままでは、特定の材料を含む飲み物を検索する際に文字列マッチングが必要
- リスト化により、材料の存在確認が高速化される

### 2. 機械学習での活用

- 材料の組み合わせパターンを分析する際に、リスト形式の方が扱いやすい
- 協調フィルタリングで材料ベースの類似度計算が容易になる

### 3. レコメンデーションシステムでの活用

- ユーザーの好みの材料を基に、似た材料を含む飲み物を推薦できる
- 材料ベースの類似度計算が可能

### 4. データの構造化

- 正規化されたデータ構造により、後続の処理が統一される
- 材料の個数や種類の統計分析が簡単になる

## 技術的詳細

### 使用メソッド

- `str.split('|')`: 文字列を指定した区切り文字で分割
- `iterrows()`: DataFrame の各行を反復処理（インデックスと行データを取得）

### データ型

- 元の`ingredients`: 文字列型
- 新しい`ingredients_list`: リスト型


実行すると、CSV ファイルの読み込みから ingredients 列の分割、結果の表示まで一連の処理が実行される
